### PR TITLE
updates gevent to a version that supports python versions >= 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,11 @@ services:
 - redis-server
 python:
 - '2.7'
-- '3.3'
 - '3.4'
 - '3.5'
+- '3.6'
 install:
 - pip install -r requirements-test.txt
-- pip list
-- pip freeze
 - pip install release-manager
 - pip install -e .
 script: pytest --cov=snowplow_tracker

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,8 @@ python:
 - '3.5'
 install:
 - pip install -r requirements-test.txt
+- pip list
+- pip freeze
 - pip install release-manager
 - pip install -e .
 script: pytest --cov=snowplow_tracker

--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "requests==2.2.1",
         "pycontracts==1.7.6",
         "celery==3.1.11",
-        "gevent==1.0.2",
+        "gevent==1.4.0",
         "redis==2.9.1",
         "six==1.9.0"
     ],


### PR DESCRIPTION
The current version of gevent required  doesn't support python 3 (https://pypi.org/project/gevent/1.0.2/). This PR updates the version of gevent required so that it is supported in python 3 (https://pypi.org/project/gevent/1.4.0/).